### PR TITLE
Update dated dependency to the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Automatic install: `pip install -r requirements.txt`
 
 Tested on Python 3.5.2. May work on older versions, but not guaranteed.
 
-Requires `google-api-python-client`, available through `pip`.
+Requires `google-api-python-client` and `oauth2client`, available through `pip`.
 
 If the `gitlabApi` feature is desired, then `python-gitlab` must also be
 installed (also through `pip`).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-google-api-python-client==1.6.5
-python-gitlab==1.3.0
+google-api-python-client==2.26.1
+python-gitlab==2.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 google-api-python-client==2.26.1
+oauth2client==4.1.3
 python-gitlab==2.10.1


### PR DESCRIPTION
I've manually tested gitlab-calendar with updated dependency, and the calendar events were created and deleted with success