### PR TITLE
Prevent pip cache in Dockerfile, make Docker image smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.6.4-alpine
 WORKDIR /app
 
 COPY ./requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 


### PR DESCRIPTION
This change will make the Docker image smaller, there is no need to keep that cache in the container image.