### PR TITLE
Update Docker base image from python 3.6.4 to 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.4-alpine
+FROM python:3.10-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
Python 3.6.4 is dated, Python v3.6 was released about 5 years ago, and it's going to reach end-of-life soon(before the end of 2021).

Reference: https://devguide.python.org/#status-of-python-branches

I've manually tested gitlab-calendar with updated Python version, and the calendar events were created and deleted with success

By the way, it's interesting, but you can see that the `python:3.10-alpine` image is much more smaller than `python:3.6.4-alpine`, the extracted size is even more obvious(the size on Docker Hub is under compression):

- https://hub.docker.com/layers/python/library/python/3.6.4-alpine/images/sha256-4fcaf5fb5f2b8230c53b5fd4c4325df00021d45272dc4bfbb2148e5ca91ac166?context=explore
- https://hub.docker.com/layers/python/library/python/3.10-alpine/images/sha256-6706c76c433f8d5900269dfc6cfd91c2cd9a0682df68286cdef4d3a30263772d?context=explore

![image](https://user-images.githubusercontent.com/3691490/137511723-66a3a394-f0f1-47f0-8078-f3d0228dd762.png)
![image](https://user-images.githubusercontent.com/3691490/137511752-ef6ff4fe-a681-4beb-83bc-0e3440f5c450.png)

